### PR TITLE
Remove gradient_error_by_coefficient argument from Cost::gradient

### DIFF
--- a/src/cost.rs
+++ b/src/cost.rs
@@ -8,9 +8,9 @@ pub struct LeastSquares;
 impl Cost<f64> for LeastSquares {
     type Error = f64;
 
-    fn gradient(&self, prediction: f64, truth: f64, gradient_error_by_coefficent: f64) -> f64 {
+    fn gradient(&self, prediction: f64, truth: f64) -> f64 {
         let error = prediction - truth;
-        2.0 * error * gradient_error_by_coefficent
+        2.0 * error
     }
 
     fn cost(&self, prediction: f64, truth: f64) -> f64 {
@@ -27,12 +27,12 @@ pub struct LeastAbsoluteDeviation;
 impl Cost<f64> for LeastAbsoluteDeviation {
     type Error = f64;
 
-    fn gradient(&self, prediction: f64, truth: f64, gradient_error_by_coefficent: f64) -> f64 {
+    fn gradient(&self, prediction: f64, truth: f64) -> f64 {
         let error = prediction - truth;
         if error > 0.0 {
-            gradient_error_by_coefficent
+            1.0
         } else if error < 0.0 {
-            -gradient_error_by_coefficent
+            -1.0
         } else {
             0.0
         }
@@ -86,8 +86,8 @@ pub struct MaxLikelihood;
 impl Cost<f64> for MaxLikelihood {
     type Error = f64;
 
-    fn gradient(&self, prediction: f64, truth: f64, gradient_error_by_coefficent: f64) -> f64 {
-        gradient_error_by_coefficent * ((1.0 - truth) / (1.0 - prediction) - truth / prediction)
+    fn gradient(&self, prediction: f64, truth: f64) -> f64 {
+        ((1.0 - truth) / (1.0 - prediction) - truth / prediction)
     }
     fn cost(&self, _prediction: f64, _truth: f64) -> f64 {
         panic!("not implemented");
@@ -97,8 +97,8 @@ impl Cost<f64> for MaxLikelihood {
 impl Cost<bool> for MaxLikelihood {
     type Error = f64;
 
-    fn gradient(&self, prediction: f64, truth: bool, gradient_error_by_coefficent: f64) -> f64 {
-        gradient_error_by_coefficent / if truth { -prediction } else { 1.0 - prediction }
+    fn gradient(&self, prediction: f64, truth: bool) -> f64 {
+        1. / if truth { -prediction } else { 1.0 - prediction }
     }
     fn cost(&self, _prediction: f64, _truth: bool) -> f64 {
         panic!("not implemented");

--- a/src/cost.rs
+++ b/src/cost.rs
@@ -8,7 +8,7 @@ pub struct LeastSquares;
 impl Cost<f64> for LeastSquares {
     type Error = f64;
 
-    fn gradient(&self, prediction: f64, truth: f64) -> f64 {
+    fn outer_derivative(&self, prediction: f64, truth: f64) -> f64 {
         let error = prediction - truth;
         2.0 * error
     }
@@ -27,7 +27,7 @@ pub struct LeastAbsoluteDeviation;
 impl Cost<f64> for LeastAbsoluteDeviation {
     type Error = f64;
 
-    fn gradient(&self, prediction: f64, truth: f64) -> f64 {
+    fn outer_derivative(&self, prediction: f64, truth: f64) -> f64 {
         let error = prediction - truth;
         if error > 0.0 {
             1.0
@@ -86,7 +86,7 @@ pub struct MaxLikelihood;
 impl Cost<f64> for MaxLikelihood {
     type Error = f64;
 
-    fn gradient(&self, prediction: f64, truth: f64) -> f64 {
+    fn outer_derivative(&self, prediction: f64, truth: f64) -> f64 {
         ((1.0 - truth) / (1.0 - prediction) - truth / prediction)
     }
     fn cost(&self, _prediction: f64, _truth: f64) -> f64 {
@@ -97,7 +97,7 @@ impl Cost<f64> for MaxLikelihood {
 impl Cost<bool> for MaxLikelihood {
     type Error = f64;
 
-    fn gradient(&self, prediction: f64, truth: bool) -> f64 {
+    fn outer_derivative(&self, prediction: f64, truth: bool) -> f64 {
         1. / if truth { -prediction } else { 1.0 - prediction }
     }
     fn cost(&self, _prediction: f64, _truth: bool) -> f64 {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -64,11 +64,8 @@ pub trait Cost<Truth> {
     ///
     /// This method is called by stochastic gradient descent (SGD)-based
     /// training algorithm in order to determine the delta of the coefficents
-    fn gradient(&self,
-                prediction: Self::Error,
-                truth: Truth,
-                gradient_error_by_coefficent: Self::Error)
-                -> Self::Error;
+    fn gradient(&self, prediction: Self::Error, truth: Truth) -> Self::Error;
+
     /// Value of the cost function.
     fn cost(&self, prediction: Self::Error, truth: Truth) -> Self::Error;
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,8 +48,18 @@ pub trait Model: Clone {
 }
 
 /// Representing a cost function whose value is supposed be minimized by the
-/// training algorithm A cost function quantifies the difference between a
-/// prediction and a true target value.
+/// training algorithm.
+///
+/// The cost function is a quantity that describes how deviations of the
+/// prediction from the true, observed target values should be penalized during
+/// the optimization of the prediction.
+///
+/// Algorithms like stochastic gradient descent use the gradient of the cost
+/// function. When calculating the gradient, it is important to apply the
+/// outer-derivative of the cost function to the prediction, with the
+/// inner-derivative of the model to the coefficient changes (chain-rule of
+/// calculus). This inner-derivative must be supplied as the argument
+/// `derivative_of_model` to `Cost::gradient`.
 ///
 /// Implementations of this trait can be found in
 /// [cost](./cost/index.html)
@@ -64,7 +74,19 @@ pub trait Cost<Truth> {
     ///
     /// This method is called by stochastic gradient descent (SGD)-based
     /// training algorithm in order to determine the delta of the coefficents
-    fn gradient(&self, prediction: Self::Error, truth: Truth) -> Self::Error;
+    ///
+    /// Implementors of this trait should implement `Cost::outer_derivative` and not overwrite this
+    /// method.
+    fn gradient(&self,
+                prediction: Self::Error,
+                truth: Truth,
+                derivative_of_model: Self::Error)
+                -> Self::Error {
+        self.outer_derivative(prediction, truth) * derivative_of_model
+    }
+
+    /// The outer derivative of the cost function with respect to the prediction.
+    fn outer_derivative(&self, prediction: Self::Error, truth: Truth) -> Self::Error;
 
     /// Value of the cost function.
     fn cost(&self, prediction: Self::Error, truth: Truth) -> Self::Error;

--- a/src/training.rs
+++ b/src/training.rs
@@ -23,8 +23,8 @@ impl<M> Training for GradientDescent<M>
 
         for ci in 0..model.num_coefficents() {
             *model.coefficent(ci) = *model.coefficent(ci) -
-                                    self.learning_rate * cost.gradient(prediction, truth) *
-                                    model.gradient(ci, features);
+                                    self.learning_rate *
+                                    cost.gradient(prediction, truth, model.gradient(ci, features));
         }
     }
 }
@@ -68,8 +68,8 @@ impl<M> Training for GradientDescentAl<M>
 
         for ci in 0..model.num_coefficents() {
             *model.coefficent(ci) = *model.coefficent(ci) -
-                                    self.learning_rate() * cost.gradient(prediction, truth) *
-                                    model.gradient(ci, features);
+                                    self.learning_rate() *
+                                    cost.gradient(prediction, truth, model.gradient(ci, features));
         }
 
         self.learned_events = self.learned_events + M::Target::one();
@@ -123,8 +123,8 @@ impl<M> Training for Momentum<M>
 
         for ci in 0..model.num_coefficents() {
             self.velocity[ci] = self.inertia * self.velocity[ci] -
-                                self.learning_rate() * cost.gradient(prediction, truth) *
-                                model.gradient(ci, features);
+                                self.learning_rate() *
+                                cost.gradient(prediction, truth, model.gradient(ci, features));
             *model.coefficent(ci) = *model.coefficent(ci) + self.velocity[ci];
         }
 
@@ -190,8 +190,8 @@ impl<M> Training for Nesterov<M>
         }
 
         for ci in 0..model.num_coefficents() {
-            let delta = -self.learning_rate() * cost.gradient(prediction, truth) *
-                        model.gradient(ci, features);
+            let delta = -self.learning_rate() *
+                        cost.gradient(prediction, truth, model.gradient(ci, features));
             *model.coefficent(ci) = *model.coefficent(ci) + delta;
             self.velocity[ci] = self.inertia * self.velocity[ci] + delta;
         }

--- a/src/training.rs
+++ b/src/training.rs
@@ -23,8 +23,8 @@ impl<M> Training for GradientDescent<M>
 
         for ci in 0..model.num_coefficents() {
             *model.coefficent(ci) = *model.coefficent(ci) -
-                                    self.learning_rate *
-                                    cost.gradient(prediction, truth, model.gradient(ci, features));
+                                    self.learning_rate * cost.gradient(prediction, truth) *
+                                    model.gradient(ci, features);
         }
     }
 }
@@ -68,8 +68,8 @@ impl<M> Training for GradientDescentAl<M>
 
         for ci in 0..model.num_coefficents() {
             *model.coefficent(ci) = *model.coefficent(ci) -
-                                    self.learning_rate() *
-                                    cost.gradient(prediction, truth, model.gradient(ci, features));
+                                    self.learning_rate() * cost.gradient(prediction, truth) *
+                                    model.gradient(ci, features);
         }
 
         self.learned_events = self.learned_events + M::Target::one();
@@ -123,8 +123,8 @@ impl<M> Training for Momentum<M>
 
         for ci in 0..model.num_coefficents() {
             self.velocity[ci] = self.inertia * self.velocity[ci] -
-                                self.learning_rate() *
-                                cost.gradient(prediction, truth, model.gradient(ci, features));
+                                self.learning_rate() * cost.gradient(prediction, truth) *
+                                model.gradient(ci, features);
             *model.coefficent(ci) = *model.coefficent(ci) + self.velocity[ci];
         }
 
@@ -190,8 +190,8 @@ impl<M> Training for Nesterov<M>
         }
 
         for ci in 0..model.num_coefficents() {
-            let delta = -self.learning_rate() *
-                        cost.gradient(prediction, truth, model.gradient(ci, features));
+            let delta = -self.learning_rate() * cost.gradient(prediction, truth) *
+                        model.gradient(ci, features);
             *model.coefficent(ci) = *model.coefficent(ci) + delta;
             self.velocity[ci] = self.inertia * self.velocity[ci] + delta;
         }


### PR DESCRIPTION
I created this PR as a PR to the base of the `cost-trait` branch, so that the diff is a bit easier and so that we can discuss how we want to refactor the gradient function's dependency on the derivative of the model (see Issue #10).

I refactored `Cost` to have a default implementation of the gradient function, and added a function `outer_derivative` for the derivative of the cost function when deriving with respect of the model-prediction.
