### PR TITLE
Model input types

### DIFF
--- a/examples/iris.rs
+++ b/examples/iris.rs
@@ -5,7 +5,7 @@ extern crate csv;
 extern crate vikos;
 extern crate rustc_serialize;
 
-use vikos::{Teacher, Model};
+use vikos::{Teacher, Expert};
 use std::default::Default;
 
 const PATH : &'static str = "examples/data/iris.csv";

--- a/examples/mean.rs
+++ b/examples/mean.rs
@@ -1,12 +1,12 @@
 extern crate vikos;
-use vikos::{model, cost, teacher, learn_history};
+use vikos::{cost, teacher, learn_history};
 
 fn main() {
 
     // mean is 9, but of course we do not know that yet
     let history = [1.0, 3.0, 4.0, 7.0, 8.0, 11.0, 29.0];
     // The mean is just a simple number ...
-    let mut model = model::Constant::new(0.0);
+    let mut model = 0.0;
     // ... which minimizes the square error
     let cost = cost::LeastSquares {};
     // Use stochasic gradient descent with an annealed learning rate
@@ -18,5 +18,5 @@ fn main() {
                   &mut model,
                   history.iter().cycle().take(100).map(|&y| ((), y)));
     // Since we know the model's type is `Constant`, we could just access the members
-    println!("{}", model.c);
+    println!("{}", model);
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,13 +4,6 @@
 //! independently of the model trained or the cost function that is meant to
 //! be minimized. To get started right away, you may want to
 //! have a look at the [tutorial](./tutorial/index.html).
-//!
-//! # Design
-//! The three most important traits are [Model], [Cost] and [Teacher].
-//!
-//! [Model]: ./trait.Model.html
-//! [Cost]: ./trait.Cost.html
-//! [Teacher]: ./trait.Teacher.html
 
 #![warn(missing_docs)]
 #![cfg_attr(feature="clippy", feature(plugin))]
@@ -23,7 +16,6 @@ use std::iter::IntoIterator;
 
 /// Allows accessing and changing coefficents
 pub trait Model {
-
     /// The number of internal coefficents this model depends on
     fn num_coefficents(&self) -> usize;
 
@@ -35,8 +27,7 @@ pub trait Model {
 ///
 /// Implementations of this trait can be found in
 /// [models](./model/index.html)
-pub trait Expert<X> : Model{
-
+pub trait Expert<X>: Model {
     /// Predicts a target for the inputs based on the internal coefficents
     fn predict(&self, &X) -> f64;
 
@@ -94,11 +85,11 @@ pub trait Teacher<M: Model> {
 
     /// Changes `model`s coefficents so they minimize the `cost` function (hopefully)
     fn teach_event<X, Y, C>(&self,
-                         training: &mut Self::Training,
-                         model: &mut M,
-                         cost: &C,
-                         features: &X,
-                         truth: Y)
+                            training: &mut Self::Training,
+                            model: &mut M,
+                            cost: &C,
+                            features: &X,
+                            truth: Y)
         where C: Cost<Y>,
               Y: Copy,
               M: Expert<X>;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,18 +25,16 @@ use std::iter::IntoIterator;
 ///
 /// Implementations of this trait can be found in
 /// [models](./model/index.html)
-pub trait Model {
-    /// Input features
-    type Input;
+pub trait Model<X> {
 
     /// Predicts a target for the inputs based on the internal coefficents
-    fn predict(&self, &Self::Input) -> f64;
+    fn predict(&self, &X) -> f64;
 
     /// The number of internal coefficents this model depends on
     fn num_coefficents(&self) -> usize;
 
     /// Value predict derived by the n-th `coefficent` at `input`
-    fn gradient(&self, coefficent: usize, input: &Self::Input) -> f64;
+    fn gradient(&self, coefficent: usize, input: &X) -> f64;
 
     /// Mutable reference to the n-th `coefficent`
     fn coefficent(&mut self, coefficent: usize) -> &mut f64;
@@ -79,7 +77,7 @@ pub trait Cost<Truth> {
 }
 
 /// Algorithms used to adapt [Model](./trait.Model.html) coefficents
-pub trait Teacher<M: Model> {
+pub trait Teacher<X, M: Model<X>> {
     /// Contains state which changes during the training, but is not part of the expertise
     ///
     /// Examples are the velocity of the coefficents (in stochastic gradient
@@ -95,18 +93,18 @@ pub trait Teacher<M: Model> {
                          training: &mut Self::Training,
                          model: &mut M,
                          cost: &C,
-                         features: &M::Input,
+                         features: &X,
                          truth: Y)
         where C: Cost<Y>,
               Y: Copy;
 }
 
 /// Teaches `model` all events in `history`
-pub fn learn_history<M, C, T, H, Truth>(teacher: &T, cost: &C, model: &mut M, history: H)
-    where M: Model,
+pub fn learn_history<X, M, C, T, H, Truth>(teacher: &T, cost: &C, model: &mut M, history: H)
+    where M: Model<X>,
           C: Cost<Truth>,
-          T: Teacher<M>,
-          H: IntoIterator<Item = (M::Input, Truth)>,
+          T: Teacher<X, M>,
+          H: IntoIterator<Item = (X, Truth)>,
           Truth: Copy
 {
     let mut training = teacher.new_training(model);

--- a/src/model.rs
+++ b/src/model.rs
@@ -2,8 +2,7 @@ use Model;
 use Expert;
 use linear_algebra::Vector;
 
-impl Model for f64{
-
+impl Model for f64 {
     fn num_coefficents(&self) -> usize {
         1
     }
@@ -14,11 +13,9 @@ impl Model for f64{
             _ => panic!("coefficent index out of range"),
         }
     }
-
 }
 
 impl<I> Expert<I> for f64 {
-
     fn predict(&self, _: &I) -> f64 {
         *self
     }

--- a/src/model.rs
+++ b/src/model.rs
@@ -2,53 +2,7 @@ use Model;
 use Expert;
 use linear_algebra::Vector;
 
-/// Models the target as a constant `c`
-///
-/// This model predicts a number. The cost function used during training decides
-/// whether this number is a mean, median, or something else.
-///
-/// # Examples
-///
-/// Estimate mean
-///
-/// ```
-/// use vikos::model::Constant;
-/// use vikos::cost::LeastSquares;
-/// use vikos::teacher::GradientDescentAl;
-/// use vikos::learn_history;
-///
-/// let features = ();
-/// let history = [1f64, 3.0, 4.0, 7.0, 8.0, 11.0, 29.0]; //mean is 9
-///
-/// let cost = LeastSquares{};
-/// let mut model = Constant::new(0.0);
-///
-/// let teacher = GradientDescentAl{ l0 : 0.3, t : 4.0 };
-/// learn_history(&teacher, &cost, &mut model, history.iter().cycle().map(|&y|((),y)).take(100));
-/// println!("{}", model.c);
-/// ```
-#[derive(Debug, Default, RustcDecodable, RustcEncodable)]
-pub struct Constant {
-    /// Any prediction made by this model will have the value of `c`
-    pub c: f64
-}
-
-impl Constant {
-    /// Creates a new Constant from a `f64`
-    pub fn new(c: f64) -> Constant {
-        Constant {
-            c: c
-        }
-    }
-}
-
-impl Clone for Constant {
-    fn clone(&self) -> Self {
-        Constant::new(self.c)
-    }
-}
-
-impl Model for Constant{
+impl Model for f64{
 
     fn num_coefficents(&self) -> usize {
         1
@@ -56,17 +10,17 @@ impl Model for Constant{
 
     fn coefficent(&mut self, coefficent: usize) -> &mut f64 {
         match coefficent {
-            0 => &mut self.c,
+            0 => self,
             _ => panic!("coefficent index out of range"),
         }
     }
 
 }
 
-impl<I> Expert<I> for Constant {
+impl<I> Expert<I> for f64 {
 
     fn predict(&self, _: &I) -> f64 {
-        self.c
+        *self
     }
 
     fn gradient(&self, coefficent: usize, _: &I) -> f64 {

--- a/src/model.rs
+++ b/src/model.rs
@@ -50,8 +50,7 @@ impl<I> Clone for Constant<I> {
     }
 }
 
-impl<I> Model for Constant<I> {
-    type Input = I;
+impl<I> Model<I> for Constant<I> {
 
     fn predict(&self, _: &I) -> f64 {
         self.c
@@ -85,10 +84,9 @@ pub struct Linear<V: Vector> {
     pub c: V::Scalar,
 }
 
-impl<V> Model for Linear<V>
+impl<V> Model<V> for Linear<V>
     where V: Vector<Scalar = f64>
 {
-    type Input = V;
 
     fn predict(&self, input: &V) -> V::Scalar {
         self.m.dot(input) + self.c
@@ -122,11 +120,9 @@ impl<V> Model for Linear<V>
 #[derive(Debug, Clone, Default, RustcDecodable, RustcEncodable)]
 pub struct Logistic<V: Vector>(Linear<V>);
 
-impl<V> Model for Logistic<V>
+impl<V> Model<V> for Logistic<V>
     where V: Vector<Scalar = f64>
 {
-    type Input = V;
-
     fn predict(&self, input: &V) -> f64 {
         1.0 / (1.0 + self.0.predict(input).exp())
     }
@@ -192,13 +188,11 @@ impl<V, G, Dg> GeneralizedLinearModel<V, G, Dg>
     }
 }
 
-impl<V, F, Df> Model for GeneralizedLinearModel<V, F, Df>
+impl<V, F, Df> Model<V> for GeneralizedLinearModel<V, F, Df>
     where F: Fn(f64) -> f64,
           Df: Fn(f64) -> f64,
           V: Vector<Scalar = f64>
 {
-    type Input = V;
-
     fn predict(&self, input: &V) -> f64 {
         let f = &self.g;
         f(self.linear.predict(&input))

--- a/src/teacher.rs
+++ b/src/teacher.rs
@@ -13,8 +13,8 @@ pub struct GradientDescent {
     pub learning_rate: f64,
 }
 
-impl<M> Teacher<M> for GradientDescent
-    where M: Model
+impl<X, M> Teacher<X, M> for GradientDescent
+    where M: Model<X>
 {
     type Training = ();
 
@@ -26,7 +26,7 @@ impl<M> Teacher<M> for GradientDescent
                          _training: &mut (),
                          model: &mut M,
                          cost: &C,
-                         features: &M::Input,
+                         features: &X,
                          truth: Y)
         where C: Cost<Y>,
               Y: Copy
@@ -55,8 +55,8 @@ pub struct GradientDescentAl {
     pub t: f64,
 }
 
-impl<M> Teacher<M> for GradientDescentAl
-    where M: Model
+impl<X, M> Teacher<X, M> for GradientDescentAl
+    where M: Model<X>
 {
     type Training = usize;
 
@@ -68,7 +68,7 @@ impl<M> Teacher<M> for GradientDescentAl
                          num_events: &mut usize,
                          model: &mut M,
                          cost: &C,
-                         features: &M::Input,
+                         features: &X,
                          truth: Y)
         where C: Cost<Y>,
               Y: Copy
@@ -101,8 +101,8 @@ pub struct Momentum {
     pub inertia: f64,
 }
 
-impl<M> Teacher<M> for Momentum
-    where M: Model
+impl<X, M> Teacher<X, M> for Momentum
+    where M: Model<X>
 {
     type Training = (usize, Vec<f64>);
 
@@ -118,7 +118,7 @@ impl<M> Teacher<M> for Momentum
                          training: &mut (usize, Vec<f64>),
                          model: &mut M,
                          cost: &C,
-                         features: &M::Input,
+                         features: &X,
                          truth: Y)
         where C: Cost<Y>,
               Y: Copy
@@ -161,8 +161,8 @@ pub struct Nesterov {
     pub inertia: f64,
 }
 
-impl<M> Teacher<M> for Nesterov
-    where M: Model
+impl<X, M> Teacher<X, M> for Nesterov
+    where M: Model<X>
 {
     type Training = (usize, Vec<f64>);
 
@@ -178,7 +178,7 @@ impl<M> Teacher<M> for Nesterov
                          training: &mut (usize, Vec<f64>),
                          model: &mut M,
                          cost: &C,
-                         features: &M::Input,
+                         features: &X,
                          truth: Y)
         where C: Cost<Y>,
               Y: Copy

--- a/src/teacher.rs
+++ b/src/teacher.rs
@@ -24,11 +24,11 @@ impl<M> Teacher<M> for GradientDescent
     }
 
     fn teach_event<X, Y, C>(&self,
-                         _training: &mut (),
-                         model: &mut M,
-                         cost: &C,
-                         features: &X,
-                         truth: Y)
+                            _training: &mut (),
+                            model: &mut M,
+                            cost: &C,
+                            features: &X,
+                            truth: Y)
         where C: Cost<Y>,
               Y: Copy,
               M: Expert<X>
@@ -67,11 +67,11 @@ impl<M> Teacher<M> for GradientDescentAl
     }
 
     fn teach_event<X, Y, C>(&self,
-                         num_events: &mut usize,
-                         model: &mut M,
-                         cost: &C,
-                         features: &X,
-                         truth: Y)
+                            num_events: &mut usize,
+                            model: &mut M,
+                            cost: &C,
+                            features: &X,
+                            truth: Y)
         where C: Cost<Y>,
               Y: Copy,
               M: Expert<X>
@@ -118,11 +118,11 @@ impl<M> Teacher<M> for Momentum
     }
 
     fn teach_event<X, Y, C>(&self,
-                         training: &mut (usize, Vec<f64>),
-                         model: &mut M,
-                         cost: &C,
-                         features: &X,
-                         truth: Y)
+                            training: &mut (usize, Vec<f64>),
+                            model: &mut M,
+                            cost: &C,
+                            features: &X,
+                            truth: Y)
         where C: Cost<Y>,
               Y: Copy,
               M: Expert<X>
@@ -179,11 +179,11 @@ impl<M> Teacher<M> for Nesterov
     }
 
     fn teach_event<X, Y, C>(&self,
-                         training: &mut (usize, Vec<f64>),
-                         model: &mut M,
-                         cost: &C,
-                         features: &X,
-                         truth: Y)
+                            training: &mut (usize, Vec<f64>),
+                            model: &mut M,
+                            cost: &C,
+                            features: &X,
+                            truth: Y)
         where C: Cost<Y>,
               Y: Copy,
               M: Expert<X>

--- a/src/teacher.rs
+++ b/src/teacher.rs
@@ -3,6 +3,7 @@
 use ::training;
 use Teacher;
 use Model;
+use Expert;
 use Cost;
 
 /// Gradient descent
@@ -13,8 +14,8 @@ pub struct GradientDescent {
     pub learning_rate: f64,
 }
 
-impl<X, M> Teacher<X, M> for GradientDescent
-    where M: Model<X>
+impl<M> Teacher<M> for GradientDescent
+    where M: Model
 {
     type Training = ();
 
@@ -22,14 +23,15 @@ impl<X, M> Teacher<X, M> for GradientDescent
         ()
     }
 
-    fn teach_event<Y, C>(&self,
+    fn teach_event<X, Y, C>(&self,
                          _training: &mut (),
                          model: &mut M,
                          cost: &C,
                          features: &X,
                          truth: Y)
         where C: Cost<Y>,
-              Y: Copy
+              Y: Copy,
+              M: Expert<X>
     {
         let prediction = model.predict(features);
 
@@ -55,8 +57,8 @@ pub struct GradientDescentAl {
     pub t: f64,
 }
 
-impl<X, M> Teacher<X, M> for GradientDescentAl
-    where M: Model<X>
+impl<M> Teacher<M> for GradientDescentAl
+    where M: Model
 {
     type Training = usize;
 
@@ -64,14 +66,15 @@ impl<X, M> Teacher<X, M> for GradientDescentAl
         0
     }
 
-    fn teach_event<Y, C>(&self,
+    fn teach_event<X, Y, C>(&self,
                          num_events: &mut usize,
                          model: &mut M,
                          cost: &C,
                          features: &X,
                          truth: Y)
         where C: Cost<Y>,
-              Y: Copy
+              Y: Copy,
+              M: Expert<X>
     {
         let prediction = model.predict(features);
         let learning_rate = training::annealed_learning_rate(*num_events, self.l0, self.t);
@@ -101,8 +104,8 @@ pub struct Momentum {
     pub inertia: f64,
 }
 
-impl<X, M> Teacher<X, M> for Momentum
-    where M: Model<X>
+impl<M> Teacher<M> for Momentum
+    where M: Model
 {
     type Training = (usize, Vec<f64>);
 
@@ -114,14 +117,15 @@ impl<X, M> Teacher<X, M> for Momentum
         (0, velocity)
     }
 
-    fn teach_event<Y, C>(&self,
+    fn teach_event<X, Y, C>(&self,
                          training: &mut (usize, Vec<f64>),
                          model: &mut M,
                          cost: &C,
                          features: &X,
                          truth: Y)
         where C: Cost<Y>,
-              Y: Copy
+              Y: Copy,
+              M: Expert<X>
     {
         // let (ref mut num_events, ref mut velocity) = *training; ok?
         let mut num_events = &mut training.0;
@@ -161,8 +165,8 @@ pub struct Nesterov {
     pub inertia: f64,
 }
 
-impl<X, M> Teacher<X, M> for Nesterov
-    where M: Model<X>
+impl<M> Teacher<M> for Nesterov
+    where M: Model
 {
     type Training = (usize, Vec<f64>);
 
@@ -174,14 +178,15 @@ impl<X, M> Teacher<X, M> for Nesterov
         (0, velocity)
     }
 
-    fn teach_event<Y, C>(&self,
+    fn teach_event<X, Y, C>(&self,
                          training: &mut (usize, Vec<f64>),
                          model: &mut M,
                          cost: &C,
                          features: &X,
                          truth: Y)
         where C: Cost<Y>,
-              Y: Copy
+              Y: Copy,
+              M: Expert<X>
     {
 
         let mut num_events = &mut training.0;

--- a/src/tutorial.rs
+++ b/src/tutorial.rs
@@ -43,14 +43,12 @@
 //!               &cost,
 //!               &mut model,
 //!               history.iter().cycle().take(100).cloned());
-//! // Since we know the model's type is `Constant`, we could just access the members
+//! // Since we know the model's type is `f64`, we can just print it
 //! println!("{}", model);
 //! ```
-//! As far as the mean is concerned, the first element of each tuple, i.e.,
-//! the feature, is just ignored (because we use the
-//! [Constant](../model/struct.Constant.html) model).  The code would also
-//! compile if the first element would be an empty tuple or any other type for
-//! that matter.
+//! As far as the mean is concerned, the first element of each tuple, i.e., the feature, is just
+//! ignored. The code would also compile if the first element would be an empty tuple or any other
+//! type for that matter.
 //!
 //! ## Estimating the median target value
 //!
@@ -144,16 +142,18 @@
 //! }
 //! println!("slope: {}, intercept: {}", model.m, model.c);
 //! ```
+//! Note the use of the [Expert](../trait.Expert.html) trait to predict the target based the input.
+//!
 //! # Summary
 //!
 //! Using Vikos, we can build a machine-learning model by composing
 //! implementations of three aspects:
 //!
-//!  * the [Model](../trait.Model.html) describes how features and target
-//!    relate to each other (and what kind of estimated parameters/coefficients
-//!    mediate among the target and the feature space), the model is  fitted by
-//!  * the training algorithm, modelled with the
-//!    [Teacher](../trait.Teacher.html) trait, that contains the optimization algorithm minimizing
-//!    the model coefficents.
-//!  * the [Cost](../trait.Cost.html) "function" describes the function that
-//!    should be minimized by the algorithm.
+//!  * the describes how features and target relate to each other using an
+//!    [Expert](../trait.Expert.html) algorithm and what kind of estimated parameters/coefficients
+//!    mediate among the target and the feature space ([Model](../trait.Model.html)), the model is
+//!    fitted by
+//!  * the training algorithm, modelled with the [Teacher](../trait.Teacher.html) trait, that
+//!    contains the optimization algorithm minimizing the model coefficents.
+//!  * the [Cost](../trait.Cost.html) "function" describes the function that should be minimized by
+//!    the algorithm.

--- a/src/tutorial.rs
+++ b/src/tutorial.rs
@@ -24,7 +24,7 @@
 //! ## Estimating the mean target value
 //!
 //! ```
-//! use vikos::{model, cost, teacher, learn_history, Expert};
+//! use vikos::{cost, teacher, learn_history};
 //! // mean is 9, but of course we do not know that yet
 //! let history = [
 //!    (2.0, 1.0), (3.0, 3.0), (3.5, 4.0),
@@ -33,7 +33,7 @@
 //! ];
 //!
 //! // The mean is just a simple number ...
-//! let mut model = model::Constant::new(0.0);
+//! let mut model = 0.0;
 //! // ... which minimizes the square error
 //! let cost = cost::LeastSquares {};
 //! // Use stochastic gradient descent with an annealed learning rate
@@ -43,10 +43,8 @@
 //!               &cost,
 //!               &mut model,
 //!               history.iter().cycle().take(100).cloned());
-//! // We need an input vector for predictions, the 42 will not influence the mean
-//! println!("{}", model.predict(&42.0));
 //! // Since we know the model's type is `Constant`, we could just access the members
-//! println!("{}", model.c);
+//! println!("{}", model);
 //! ```
 //! As far as the mean is concerned, the first element of each tuple, i.e.,
 //! the feature, is just ignored (because we use the
@@ -60,7 +58,7 @@
 //! our cost function, to that of an absolute error:
 //!
 //! ```
-//! use vikos::{model, cost, teacher, learn_history, Expert};
+//! use vikos::{cost, teacher, learn_history};
 //! let history = [
 //!    (2.0, 1.0), (3.0, 3.0), (3.5, 4.0),
 //!    (5.0, 7.0), (5.5, 8.0), (7.0, 11.0),
@@ -69,7 +67,7 @@
 //! // median is 7, but we don't know that yet of course
 //!
 //! // The median is just a simple number ...
-//! let mut model = model::Constant::new(0.0);
+//! let mut model = 0.0;
 //! // ... which minimizes the absolute error
 //! let cost = cost::LeastAbsoluteDeviation {};
 //! let teacher = teacher::GradientDescentAl { l0: 1.0, t: 9.0 };
@@ -85,7 +83,7 @@
 //! ## Estimating median again
 //!
 //! ```
-//! use vikos::{model, cost, teacher, learn_history, Expert};
+//! use vikos::{cost, teacher, learn_history};
 //! // median is 7, but of course we do not know that yet
 //! let history = [
 //!    (2.0, 1.0), (3.0, 3.0), (3.5, 4.0),
@@ -94,7 +92,7 @@
 //! ];
 //!
 //! // The median is just a simple number ...
-//! let mut model = model::Constant::new(0.0);
+//! let mut model = 0.0;
 //! // ... which minimizes the absolute error
 //! let cost = cost::LeastAbsoluteDeviation {};
 //! // Use stochasic gradient descent with an annealed learning rate and momentum
@@ -107,7 +105,7 @@
 //!               &cost,
 //!               &mut model,
 //!               history.iter().cycle().take(100).cloned());
-//! println!("{}", model.predict(&42.0));
+//! println!("{}", model);
 //! ```
 //! The momentum term allowed us to drop our learning rate way quicker and to retrieve a
 //! more precise result in the same number of iterations. The algorithms and their

--- a/src/tutorial.rs
+++ b/src/tutorial.rs
@@ -24,7 +24,7 @@
 //! ## Estimating the mean target value
 //!
 //! ```
-//! use vikos::{model, cost, teacher, learn_history, Model};
+//! use vikos::{model, cost, teacher, learn_history, Expert};
 //! // mean is 9, but of course we do not know that yet
 //! let history = [
 //!    (2.0, 1.0), (3.0, 3.0), (3.5, 4.0),
@@ -60,7 +60,7 @@
 //! our cost function, to that of an absolute error:
 //!
 //! ```
-//! use vikos::{model, cost, teacher, learn_history, Model};
+//! use vikos::{model, cost, teacher, learn_history, Expert};
 //! let history = [
 //!    (2.0, 1.0), (3.0, 3.0), (3.5, 4.0),
 //!    (5.0, 7.0), (5.5, 8.0), (7.0, 11.0),
@@ -85,7 +85,7 @@
 //! ## Estimating median again
 //!
 //! ```
-//! use vikos::{model, cost, teacher, learn_history, Model};
+//! use vikos::{model, cost, teacher, learn_history, Expert};
 //! // median is 7, but of course we do not know that yet
 //! let history = [
 //!    (2.0, 1.0), (3.0, 3.0), (3.5, 4.0),
@@ -119,7 +119,7 @@
 //! We now use a linear model
 //!
 //! ```
-//! use vikos::{model, cost, teacher, learn_history, Model};
+//! use vikos::{model, cost, teacher, learn_history, Expert};
 //! // Best described by 2 * m - 3
 //! let history = [
 //!    (2.0, 1.0), (3.0, 3.0), (3.5, 4.0),

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -170,7 +170,7 @@ fn linear_nesterov_2d() {
 #[test]
 fn logistic_sgd_2d_least_squares() {
 
-    use vikos::{learn_history, Model};
+    use vikos::{learn_history, Expert};
 
     let history = [([2.7, 2.5], 0.0),
                    ([1.4, 2.3], 0.0),
@@ -204,7 +204,7 @@ fn logistic_sgd_2d_least_squares() {
 
 #[test]
 fn logistic_sgd_2d_max_likelihood() {
-    use vikos::{learn_history, Model};
+    use vikos::{learn_history, Expert};
 
     let history = [([2.7, 2.5], 0.0),
                    ([1.4, 2.3], 0.0),
@@ -238,7 +238,7 @@ fn logistic_sgd_2d_max_likelihood() {
 
 #[test]
 fn logistic_sgd_2d_max_likelihood_bool() {
-    use vikos::{learn_history, Model};
+    use vikos::{learn_history, Expert};
 
     let history = [([2.7, 2.5], false),
                    ([1.4, 2.3], false),
@@ -272,7 +272,7 @@ fn logistic_sgd_2d_max_likelihood_bool() {
 
 #[test]
 fn generalized_linear_model_as_logistic_regression() {
-    use vikos::{learn_history, Model};
+    use vikos::{learn_history, Expert};
 
     let history = [([2.7, 2.5], false),
                    ([1.4, 2.3], false),

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -12,7 +12,7 @@ fn estimate_median() {
     let history = [1.0, 3.0, 4.0, 7.0, 8.0, 11.0, 29.0]; //median is seven
 
     let cost = cost::LeastAbsoluteDeviation {};
-    let mut model = model::Constant::new(0.0);
+    let mut model = 0.0;
 
     let teacher = teacher::GradientDescentAl { l0: 0.9, t: 9.0 };
     let mut training = teacher.new_training(&model);
@@ -25,8 +25,8 @@ fn estimate_median() {
                  training::annealed_learning_rate(training, teacher.l0, teacher.t));
     }
 
-    assert!(model.c < 7.1);
-    assert!(model.c > 6.9);
+    assert!(model < 7.1);
+    assert!(model > 6.9);
 }
 
 #[test]
@@ -38,7 +38,7 @@ fn estimate_mean() {
     let history = [1f64, 3.0, 4.0, 7.0, 8.0, 11.0, 29.0]; //mean is 9
 
     let cost = cost::LeastSquares {};
-    let mut model = model::Constant::new(0.0);
+    let mut model = 0.0;
 
     let teacher = teacher::GradientDescentAl { l0: 0.3, t: 4.0 };
     let mut training = teacher.new_training(&model);
@@ -51,8 +51,8 @@ fn estimate_mean() {
                  training::annealed_learning_rate(training, teacher.l0, teacher.t));
     }
 
-    assert!(model.c < 9.1);
-    assert!(model.c > 8.9);
+    assert!(model < 9.1);
+    assert!(model > 8.9);
 }
 
 #[test]


### PR DESCRIPTION
This branch splits the old Model trait into a new Model trait for accessing the coefficients and an Expert trait for modeling the relation between that coefficients and the target.

Motivation:
This branch started out with the humble goal to remove the `std::marker::PhantomData` hack in `model::Constant` which has been required for type inference to kick in, so that the user does not have to specify the feature type explicitly. However the only way to get rid of it without breaking type inference, has been to split the Model trait as stated above. Despite born out of technical necessity to please the compiler, I found that this split has intriguing consequences for the domain of ML:
Consider the urban legend about the [barometer question](https://en.wikipedia.org/wiki/Barometer_question). Niels Bohr was supposedly asked to determine the height of the building using a barometer. Among others he suggested:
1. Throwing the barometer from a building
2. Marking off the number of barometer lengths vertically along the emergency staircase
3. Measuring the pressure difference between ground and roof
Let's say we'd have to set of measurements for 1,2 and 3. We can write three Experts for the same set of coefficients (in that case the height of the building). The generalization still works even if not all experts use all coefficients (e.g. if the length of the barometer would be unknown. We would when need to learn it, but only 2 is influenced by this).

On a less philosophical note this branch allowed to implement the Model trait directly for `f64` and get rid of `Constant`. Once the target type is generic it will allow the same classifier to implement an Expert returning a crisp prediction (true | false) or a probability (f64)
