### PR TITLE
Multiclass

### DIFF
--- a/examples/iris.rs
+++ b/examples/iris.rs
@@ -6,7 +6,6 @@ extern crate vikos;
 extern crate rustc_serialize;
 
 use vikos::{Teacher, Model, Cost};
-use vikos::linear_algebra::Vector;
 use std::default::Default;
 
 const PATH: &'static str = "examples/data/iris.csv";
@@ -48,63 +47,9 @@ impl Model for IrisModel {
     }
 }
 
-struct IrisTeacher {
-    /// Start learning rate
-    pub l0: f64,
-    /// Smaller t will decrease the learning rate faster
-    ///
-    /// After t events the start learning rate will be a half `l0`,
-    /// after two t events the learning rate will be one third `l0`,
-    /// and so on.
-    pub t: f64,
-    /// To simulate friction, please select a value smaller than 1 (recommended)
-    pub inertia: f64,
-}
-
-impl<M> Teacher<M> for IrisTeacher
-    where M: Model<Target = [f64; 3]>
-{
-    type Training = (usize, Vec<f64>);
-
-    fn new_training(&self, model: &M) -> (usize, Vec<f64>) {
-
-        let mut velocity = Vec::with_capacity(model.num_coefficients());
-        velocity.resize(model.num_coefficients(), 0.0);
-
-        (0, velocity)
-    }
-
-    fn teach_event<Y, C>(&self,
-                         training: &mut Self::Training,
-                         model: &mut M,
-                         cost: &C,
-                         features: &M::Features,
-                         truth: Y)
-        where C: Cost<Y, [f64; 3]>,
-              Y: Copy
-    {
-        let mut num_events = &mut training.0;
-        let mut velocity = &mut training.1;
-        let prediction = model.predict(features);
-        let learning_rate = self.l0 / (1.0 + *num_events as f64 / self.t);
-
-        for ci in 0..model.num_coefficients() {
-            *model.coefficient(ci) = *model.coefficient(ci) + velocity[ci];
-        }
-        for ci in 0..model.num_coefficients() {
-            let delta = -learning_rate *
-                        cost.outer_derivative(&prediction, truth)
-                .dot(&model.gradient(ci, features));
-            *model.coefficient(ci) = *model.coefficient(ci) + delta;
-            velocity[ci] = self.inertia * velocity[ci] + delta;
-        }
-        *num_events += 1;
-    }
-}
-
 fn main() {
 
-    let teacher = IrisTeacher {
+    let teacher = vikos::teacher::Nesterov {
         l0: 0.0001,
         t: 1000.0,
         inertia: 0.99,

--- a/examples/iris.rs
+++ b/examples/iris.rs
@@ -5,7 +5,7 @@ extern crate csv;
 extern crate vikos;
 extern crate rustc_serialize;
 
-use vikos::{Teacher, Model, Cost};
+use vikos::{Teacher, Model};
 use std::default::Default;
 
 const PATH: &'static str = "examples/data/iris.csv";

--- a/examples/iris.rs
+++ b/examples/iris.rs
@@ -5,32 +5,89 @@ extern crate csv;
 extern crate vikos;
 extern crate rustc_serialize;
 
-use vikos::{Teacher, Model};
+use vikos::{Teacher, Model, Cost};
 use std::default::Default;
 
-const PATH : &'static str = "examples/data/iris.csv";
+const PATH: &'static str = "examples/data/iris.csv";
 
-type Features = [f64;4];
+type Features = [f64; 4];
 
-fn main() {
-
-    let teacher = vikos::teacher::Nesterov{l0 : 0.0001, t: 1000.0, inertia: 0.99};
-    let cost = vikos::cost::MaxLikelihood{};
-
+#[derive(Default)]
+struct IrisModel {
     // We train three binary classifiers. One for each specis of iris.
     // Each of this classifiers will tell us the propability of an
     // observation belonging to its particular class
-    let mut setosa = vikos::model::Logistic::default();
-    let mut versicolor = vikos::model::Logistic::default();
-    let mut virginica = vikos::model::Logistic::default();
+    class_models: [vikos::model::Logistic<Features>; 3],
+}
+
+impl Model for IrisModel {
+    type Features = Features;
+    type Target = [f64; 3];
+
+    fn num_coefficients(&self) -> usize {
+        // self.class_models.map(|m| m.num_coefficients()).sum()
+        3 * (4 + 1)
+    }
+
+    fn coefficient(&mut self, index: usize) -> &mut f64 {
+        self.class_models[index / (4 + 1)].coefficient(index % (4 + 1))
+    }
+
+    fn predict(&self, input: &Self::Features) -> Self::Target {
+        [self.class_models[0].predict(input),
+         self.class_models[1].predict(input),
+         self.class_models[2].predict(input)]
+    }
+
+    fn gradient(&self, coefficient: usize, input: &Self::Features) -> f64 {
+        0.0
+    }
+}
+
+struct IrisTeacher {
+    teacher: vikos::teacher::Nesterov,
+}
+
+impl Teacher<IrisModel> for IrisTeacher {
+    type Training = [<vikos::teacher::Nesterov as Teacher<vikos::model::Logistic<Features>>>::Training; 3];
+
+    fn new_training(&self, model: &IrisModel) -> Self::Training {
+        // Each of the classifieres has its own training state
+        [self.teacher.new_training(&model.class_models[0]),
+         self.teacher.new_training(&model.class_models[1]),
+         self.teacher.new_training(&model.class_models[2])]
+    }
+
+    fn teach_event<Y, C>(&self,
+                         training: &mut Self::Training,
+                         model: &mut IrisModel,
+                         cost: &C,
+                         features: &Features,
+                         truth: Y)
+        where C: Cost<Y>,
+              Y: Copy
+    {
+    }
+}
+
+fn main() {
+
+    let teacher = IrisTeacher {
+        teacher: vikos::teacher::Nesterov {
+            l0: 0.0001,
+            t: 1000.0,
+            inertia: 0.99,
+        },
+    };
+    let cost = vikos::cost::MaxLikelihood {};
+
+    let mut model = IrisModel::default();
 
     // Each of the classifieres has its own training state
-    let mut train_setosa = teacher.new_training(&setosa);
-    let mut train_versicolor = teacher.new_training(&versicolor);
-    let mut train_virginica = teacher.new_training(&virginica);
+    let mut training = teacher.new_training(&model);
 
     // Read iris Data
-    for epoch in 0..300{
+    for epoch in 0..300 {
         let mut rdr = csv::Reader::from_file(PATH).expect("File is ok");
         let mut hit = 0;
         let mut miss = 0;
@@ -38,22 +95,36 @@ fn main() {
         for row in rdr.decode() {
 
             // Learn event
-            let (truth, features) : (String, Features) = row.unwrap();
-            teacher.teach_event(&mut train_setosa, &mut setosa, &cost, &features, truth == "setosa");
-            teacher.teach_event(&mut train_versicolor, &mut versicolor, &cost, &features, truth == "versicolor");
-            teacher.teach_event(&mut train_virginica, &mut virginica, &cost, &features, truth == "virginica");
+            let (truth, features): (String, Features) = row.unwrap();
 
-            // Make prediction using current expertise
-            let p_setosa = setosa.predict(&features);
-            let p_versicolor = versicolor.predict(&features);
-            let p_virginica = virginica.predict(&features);
-            let prediction = if p_setosa > p_versicolor {
-                if p_setosa > p_virginica { "setosa" } else { "virginica" }
-            } else {
-                if p_versicolor > p_virginica { "versicolor" } else { "virginica" }
+            let class = match truth.as_ref() {
+                "setosa" => 0,
+                "versicolor" => 1,
+                "virginica" => 2,
+                _ => panic!("unknown Iris class: {}", truth),
             };
 
-            if prediction == truth{
+            for i in 0..3 {
+                teacher.teacher.teach_event(&mut training[i],
+                                            &mut model.class_models[i],
+                                            &cost,
+                                            &features,
+                                            class == i);
+            }
+
+            // Make prediction using current expertise
+            let p = model.predict(&features);
+            let prediction = if p[0] > p[1] {
+                if p[0] > p[2] { "setosa" } else { "virginica" }
+            } else {
+                if p[1] > p[2] {
+                    "versicolor"
+                } else {
+                    "virginica"
+                }
+            };
+
+            if prediction == truth {
                 hit += 1;
             } else {
                 miss += 1;

--- a/examples/iris.rs
+++ b/examples/iris.rs
@@ -48,8 +48,11 @@ fn main() {
             teacher.teach_event(&mut training, &mut model, &cost, &features, class);
 
             // Make prediction using current expertise
-            let p = model.predict(&features);
-            let prediction = (0..3).fold(0, |m, c| if p[c] > p[m] { c } else { m });
+            let prediction = model.predict(&features)
+                .iter()
+                .enumerate()
+                .fold((0, 0.0), |m, (i, &v)| if v > m.1 { (i, v) } else { m })
+                .0;
 
             if prediction == class {
                 hit += 1;

--- a/src/array.rs
+++ b/src/array.rs
@@ -17,23 +17,6 @@ pub trait Array {
     fn at_mut(&mut self, index: usize) -> &mut Self::Element;
 }
 
-// impl<T> Array for Vec<T> {
-//     type Element = T;
-//     type Vector = Vec<f64>;
-
-//     fn length(&self) -> usize {
-//         self.length()
-//     }
-
-//     fn at_ref(&self, index: usize) -> &T {
-//         &self[index]
-//     }
-
-//     fn at_mut(&mut self, index: usize) -> &mut T {
-//         &mut self[index]
-//     }
-// }
-
 macro_rules! array_impl_for {
     ($v:expr) => {
         impl<T> Array for [T; $v] {

--- a/src/array.rs
+++ b/src/array.rs
@@ -1,0 +1,87 @@
+//! Helper Module to treat Vec and fixed sized arrays as generic in some contexts
+use linear_algebra::Vector;
+
+/// This trait is used to make up for the lack of generics over array lengths
+pub trait Array {
+    /// Element type of the array
+    type Element;
+
+    /// Corresponding Vector type with same dimension
+    type Vector: Vector;
+
+    /// Number of elements within the array
+    fn length(&self) -> usize;
+    /// Access element by immutable reference
+    fn at_ref(&self, index: usize) -> &Self::Element;
+    /// Access element by mutable reference
+    fn at_mut(&mut self, index: usize) -> &mut Self::Element;
+}
+
+// impl<T> Array for Vec<T> {
+//     type Element = T;
+//     type Vector = Vec<f64>;
+
+//     fn length(&self) -> usize {
+//         self.length()
+//     }
+
+//     fn at_ref(&self, index: usize) -> &T {
+//         &self[index]
+//     }
+
+//     fn at_mut(&mut self, index: usize) -> &mut T {
+//         &mut self[index]
+//     }
+// }
+
+macro_rules! array_impl_for {
+    ($v:expr) => {
+        impl<T> Array for [T; $v] {
+            type Element = T;
+            type Vector = [f64; $v];
+
+            fn length(&self) -> usize{ $v }
+
+            fn at_ref(&self, index: usize) -> &T {
+                &self[index]
+            }
+
+            fn at_mut(&mut self, index: usize) -> &mut T {
+                &mut self[index]
+            }
+        }
+    }
+}
+
+array_impl_for! { 1 }
+array_impl_for! { 2 }
+array_impl_for! { 3 }
+array_impl_for! { 4 }
+array_impl_for! { 5 }
+array_impl_for! { 6 }
+array_impl_for! { 7 }
+array_impl_for! { 8 }
+array_impl_for! { 9 }
+array_impl_for! { 10 }
+array_impl_for! { 11 }
+array_impl_for! { 12 }
+array_impl_for! { 13 }
+array_impl_for! { 14 }
+array_impl_for! { 15 }
+array_impl_for! { 16 }
+array_impl_for! { 17 }
+array_impl_for! { 18 }
+array_impl_for! { 19 }
+array_impl_for! { 20 }
+array_impl_for! { 21 }
+array_impl_for! { 22 }
+array_impl_for! { 23 }
+array_impl_for! { 24 }
+array_impl_for! { 25 }
+array_impl_for! { 26 }
+array_impl_for! { 27 }
+array_impl_for! { 28 }
+array_impl_for! { 29 }
+array_impl_for! { 30 }
+array_impl_for! { 31 }
+array_impl_for! { 32 }

--- a/src/cost.rs
+++ b/src/cost.rs
@@ -1,4 +1,5 @@
 use Cost;
+use linear_algebra::Vector;
 
 /// Pass an instance of this type to a training algorithm to optimize for C=Error^2
 ///
@@ -93,16 +94,18 @@ impl Cost<bool> for MaxLikelihood {
     }
 }
 
-impl Cost<usize, [f64; 3]> for MaxLikelihood {
-    fn outer_derivative(&self, prediction: &[f64; 3], truth: usize) -> [f64; 3] {
-        let mut derivation = [0.0; 3];
-        for i in 0..3 {
-            derivation[i] = self.outer_derivative(&prediction[i], truth == i);
+impl<V> Cost<usize, V> for MaxLikelihood
+    where V: Vector
+{
+    fn outer_derivative(&self, prediction: &V, truth: usize) -> V {
+        let mut derivation = prediction.clone();
+        for i in 0..prediction.dimension() {
+            *derivation.mut_at(i) = self.outer_derivative(&prediction.at(i), truth == i);
         }
         derivation
     }
-    fn cost(&self, prediction: [f64; 3], truth: usize) -> f64 {
-        (0..3).fold(0.0, |s, i| s + self.cost(prediction[i], i == truth))
+    fn cost(&self, prediction: V, truth: usize) -> f64 {
+        (0..prediction.dimension()).fold(0.0, |s, i| s + self.cost(prediction.at(i), i == truth))
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,9 +18,13 @@ use std::iter::IntoIterator;
 ///
 /// Implementations of this trait can be found in
 /// [models](./model/index.html)
-pub trait Model{
+pub trait Model {
     /// Input from which to predict the target
     type Features;
+
+    /// f64 for Regressors or binary classifiers. Otherwise an array containing an with the
+    /// dimension of classes
+    type Target;
 
     /// The number of internal coefficients this model depends on
     fn num_coefficients(&self) -> usize;
@@ -29,7 +33,7 @@ pub trait Model{
     fn coefficient(&mut self, coefficient: usize) -> &mut f64;
 
     /// Predicts a target for the inputs based on the internal coefficients
-    fn predict(&self, &Self::Features) -> f64;
+    fn predict(&self, &Self::Features) -> Self::Target;
 
     /// Value predict derived by the n-th `coefficient` at `input`
     fn gradient(&self, coefficient: usize, input: &Self::Features) -> f64;
@@ -52,7 +56,6 @@ pub trait Model{
 /// Implementations of this trait can be found in
 /// [cost](./cost/index.html)
 pub trait Cost<Truth> {
-
     /// The outer derivative of the cost function with respect to the prediction.
     fn outer_derivative(&self, prediction: f64, truth: Truth) -> f64;
 
@@ -74,11 +77,11 @@ pub trait Teacher<M: Model> {
 
     /// Changes `model`s coefficients so they minimize the `cost` function (hopefully)
     fn teach_event<Y, C>(&self,
-                            training: &mut Self::Training,
-                            model: &mut M,
-                            cost: &C,
-                            features: &M::Features,
-                            truth: Y)
+                         training: &mut Self::Training,
+                         model: &mut M,
+                         cost: &C,
+                         features: &M::Features,
+                         truth: Y)
         where C: Cost<Y>,
               Y: Copy;
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -100,7 +100,7 @@ pub fn learn_history<M, C, T, H, Truth>(teacher: &T, cost: &C, model: &mut M, hi
         teacher.teach_event(&mut training, model, cost, &features, truth);
     }
 }
-
+mod array;
 /// Implementations of `Model` trait
 pub mod model;
 /// Implementations of `Cost` trait

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,7 +36,7 @@ pub trait Model {
     fn predict(&self, &Self::Features) -> Self::Target;
 
     /// Value predict derived by the n-th `coefficient` at `input`
-    fn gradient(&self, coefficient: usize, input: &Self::Features) -> f64;
+    fn gradient(&self, coefficient: usize, input: &Self::Features) -> Self::Target;
 }
 
 /// Representing a cost function whose value is supposed be minimized by the
@@ -55,12 +55,12 @@ pub trait Model {
 ///
 /// Implementations of this trait can be found in
 /// [cost](./cost/index.html)
-pub trait Cost<Truth> {
+pub trait Cost<Truth, Target = f64> {
     /// The outer derivative of the cost function with respect to the prediction.
-    fn outer_derivative(&self, prediction: f64, truth: Truth) -> f64;
+    fn outer_derivative(&self, prediction: &Target, truth: Truth) -> Target;
 
     /// Value of the cost function.
-    fn cost(&self, prediction: f64, truth: Truth) -> f64;
+    fn cost(&self, prediction: Target, truth: Truth) -> f64;
 }
 
 /// Algorithms used to adapt [Model](./trait.Model.html) coefficients
@@ -82,14 +82,14 @@ pub trait Teacher<M: Model> {
                          cost: &C,
                          features: &M::Features,
                          truth: Y)
-        where C: Cost<Y>,
+        where C: Cost<Y, M::Target>,
               Y: Copy;
 }
 
 /// Teaches `model` all events in `history`
 pub fn learn_history<M, C, T, H, Truth>(teacher: &T, cost: &C, model: &mut M, history: H)
     where M: Model,
-          C: Cost<Truth>,
+          C: Cost<Truth, M::Target>,
           T: Teacher<M>,
           H: IntoIterator<Item = (M::Features, Truth)>,
           Truth: Copy

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,8 +22,8 @@ pub trait Model {
     /// Input from which to predict the target
     type Features;
 
-    /// f64 for Regressors or binary classifiers. Otherwise an array containing an with the
-    /// dimension of classes
+    /// f64 for Regressors or binary classifiers. For multi classification an array of `f64` with a
+    /// dimension equal to the number of classes.
     type Target;
 
     /// The number of internal coefficients this model depends on

--- a/src/linear_algebra.rs
+++ b/src/linear_algebra.rs
@@ -20,6 +20,20 @@ pub trait Vector: Clone {
         }
         result
     }
+
+    /// Multiplies each element of the vector with `scalar`
+    fn mut_scalar_mul(&mut self, scalar: f64) {
+        for i in 0..self.dimension() {
+            *self.mut_at(i) *= scalar;
+        }
+    }
+
+    /// Multiplies each element of the vector with `scalar`
+    fn scalar_mul(self, scalar: f64) -> Self {
+        let mut result = self;
+        result.mut_scalar_mul(scalar);
+        result
+    }
 }
 
 macro_rules! vec_impl_for_array {
@@ -54,6 +68,14 @@ impl Vector for f64 {
 
     fn dot(&self, other: &Self) -> f64 {
         self * other
+    }
+
+    fn mut_scalar_mul(&mut self, scalar: f64) {
+        *self *= scalar
+    }
+
+    fn scalar_mul(self, scalar: f64) -> Self {
+        self * scalar
     }
 }
 

--- a/src/linear_algebra.rs
+++ b/src/linear_algebra.rs
@@ -3,7 +3,7 @@
 /// Assumes the `Vector` is represented as a
 /// tuple of numbers representing its projection
 /// along orthogonal base vectors
-pub trait Vector: Clone{
+pub trait Vector: Clone {
     /// Maximum allowed index for `at` and `mut_at`
     fn dimension(&self) -> usize;
     /// Length of projection along `i`-th base
@@ -36,6 +36,24 @@ macro_rules! vec_impl_for_array {
                 &mut self[index]
             }
         }
+    }
+}
+
+impl Vector for f64 {
+    fn dimension(&self) -> usize {
+        1
+    }
+    fn at(&self, i: usize) -> f64 {
+        assert!(i == 0);
+        *self
+    }
+    fn mut_at(&mut self, i: usize) -> &mut f64 {
+        assert!(i == 0);
+        self
+    }
+
+    fn dot(&self, other: &Self) -> f64 {
+        self * other
     }
 }
 

--- a/src/linear_algebra.rs
+++ b/src/linear_algebra.rs
@@ -20,20 +20,6 @@ pub trait Vector: Clone {
         }
         result
     }
-
-    /// Multiplies each element of the vector with `scalar`
-    fn mut_scalar_mul(&mut self, scalar: f64) {
-        for i in 0..self.dimension() {
-            *self.mut_at(i) *= scalar;
-        }
-    }
-
-    /// Multiplies each element of the vector with `scalar`
-    fn scalar_mul(self, scalar: f64) -> Self {
-        let mut result = self;
-        result.mut_scalar_mul(scalar);
-        result
-    }
 }
 
 macro_rules! vec_impl_for_array {
@@ -68,14 +54,6 @@ impl Vector for f64 {
 
     fn dot(&self, other: &Self) -> f64 {
         self * other
-    }
-
-    fn mut_scalar_mul(&mut self, scalar: f64) {
-        *self *= scalar
-    }
-
-    fn scalar_mul(self, scalar: f64) -> Self {
-        self * scalar
     }
 }
 

--- a/src/linear_algebra.rs
+++ b/src/linear_algebra.rs
@@ -4,6 +4,11 @@
 /// tuple of numbers representing its projection
 /// along orthogonal base vectors
 pub trait Vector: Clone {
+    /// Retuns a new instance of Vector with all elements set to zero
+    ///
+    /// Not every possible implementation knows its dimension at compiletime, therefore a size hint
+    /// is necessary to allocate the correct number of elements
+    fn zero(dimension: usize) -> Self;
     /// Maximum allowed index for `at` and `mut_at`
     fn dimension(&self) -> usize;
     /// Length of projection along `i`-th base
@@ -22,24 +27,12 @@ pub trait Vector: Clone {
     }
 }
 
-macro_rules! vec_impl_for_array {
-    ($v:expr) => {
-        impl Vector for [f64; $v] {
-
-            fn dimension(&self) -> usize{ $v }
-
-            fn at(&self, index: usize) -> f64 {
-                self[index]
-            }
-
-            fn mut_at(&mut self, index: usize) -> &mut f64 {
-                &mut self[index]
-            }
-        }
-    }
-}
-
 impl Vector for f64 {
+    fn zero(dimension: usize) -> f64 {
+        assert!(dimension == 1);
+        0.0
+    }
+
     fn dimension(&self) -> usize {
         1
     }
@@ -54,6 +47,26 @@ impl Vector for f64 {
 
     fn dot(&self, other: &Self) -> f64 {
         self * other
+    }
+}
+
+macro_rules! vec_impl_for_array {
+    ($v:expr) => {
+        impl Vector for [f64; $v] {
+            fn zero(_ : usize) -> [f64; $v]{
+                [0.0; $v]
+            }
+
+            fn dimension(&self) -> usize{ $v }
+
+            fn at(&self, index: usize) -> f64 {
+                self[index]
+            }
+
+            fn mut_at(&mut self, index: usize) -> &mut f64 {
+                &mut self[index]
+            }
+        }
     }
 }
 

--- a/src/model.rs
+++ b/src/model.rs
@@ -3,6 +3,7 @@ use linear_algebra::Vector;
 
 impl Model for f64 {
     type Features = ();
+    type Target = f64;
 
     fn num_coefficients(&self) -> usize {
         1
@@ -36,9 +37,9 @@ pub struct Linear<V> {
     pub c: f64,
 }
 
-impl Model for Linear<f64>
-{
+impl Model for Linear<f64> {
     type Features = f64;
+    type Target = f64;
 
     fn num_coefficients(&self) -> usize {
         2
@@ -66,9 +67,11 @@ impl Model for Linear<f64>
     }
 }
 
-impl<V> Model for Linear<V> where V: Vector
+impl<V> Model for Linear<V>
+    where V: Vector
 {
     type Features = V;
+    type Target = f64;
 
     fn num_coefficients(&self) -> usize {
         self.m.dimension() + 1
@@ -100,9 +103,11 @@ impl<V> Model for Linear<V> where V: Vector
 #[derive(Debug, Clone, Default, RustcDecodable, RustcEncodable)]
 pub struct Logistic<V>(Linear<V>);
 
-impl<V> Model for Logistic<V> where Linear<V>: Model<Features=V>
+impl<V> Model for Logistic<V>
+    where Linear<V>: Model<Features = V, Target = f64>
 {
     type Features = V;
+    type Target = f64;
 
     fn num_coefficients(&self) -> usize {
         self.0.num_coefficients()
@@ -171,9 +176,10 @@ impl<V, G, Dg> GeneralizedLinearModel<V, G, Dg>
 impl<V, F, Df> Model for GeneralizedLinearModel<V, F, Df>
     where F: Fn(f64) -> f64,
           Df: Fn(f64) -> f64,
-          Linear<V> : Model<Features=V>
+          Linear<V>: Model<Features = V, Target = f64>
 {
     type Features = V;
+    type Target = f64;
 
     fn num_coefficients(&self) -> usize {
         self.linear.num_coefficients()

--- a/src/model.rs
+++ b/src/model.rs
@@ -37,36 +37,6 @@ pub struct Linear<V> {
     pub c: f64,
 }
 
-impl Model for Linear<f64> {
-    type Features = f64;
-    type Target = f64;
-
-    fn num_coefficients(&self) -> usize {
-        2
-    }
-
-    fn coefficient(&mut self, coefficient: usize) -> &mut f64 {
-        if coefficient == 1 {
-            &mut self.c
-        } else {
-            &mut self.m
-        }
-    }
-
-    fn predict(&self, input: &f64) -> f64 {
-        self.m * input + self.c
-    }
-
-    fn gradient(&self, coefficient: usize, input: &f64) -> f64 {
-
-        if coefficient == 1 {
-            1.0 //derive by c
-        } else {
-            *input //derive by m
-        }
-    }
-}
-
 impl<V> Model for Linear<V>
     where V: Vector
 {

--- a/src/teacher.rs
+++ b/src/teacher.rs
@@ -22,7 +22,7 @@ fn annealed_learning_rate(num_events: usize, start: f64, t: f64) -> f64 {
 fn gradient<T, C>(cost: &C, prediction: f64, truth: T, derivative_of_model: f64) -> f64
     where C: Cost<T>
 {
-    cost.outer_derivative(prediction, truth) * derivative_of_model
+    cost.outer_derivative(&prediction, truth) * derivative_of_model
 }
 
 /// Gradient descent

--- a/src/teacher.rs
+++ b/src/teacher.rs
@@ -204,7 +204,6 @@ impl<M> Teacher<M> for Nesterov
         where C: Cost<Y>,
               Y: Copy
     {
-
         let mut num_events = &mut training.0;
         let mut velocity = &mut training.1;
         let prediction = model.predict(features);

--- a/src/teacher.rs
+++ b/src/teacher.rs
@@ -34,7 +34,7 @@ pub struct GradientDescent {
 }
 
 impl<M> Teacher<M> for GradientDescent
-    where M: Model
+    where M: Model<Target = f64>
 {
     type Training = ();
 
@@ -43,20 +43,21 @@ impl<M> Teacher<M> for GradientDescent
     }
 
     fn teach_event<Y, C>(&self,
-                            _training: &mut (),
-                            model: &mut M,
-                            cost: &C,
-                            features: &M::Features,
-                            truth: Y)
+                         _training: &mut (),
+                         model: &mut M,
+                         cost: &C,
+                         features: &M::Features,
+                         truth: Y)
         where C: Cost<Y>,
               Y: Copy
     {
         let prediction = model.predict(features);
 
         for ci in 0..model.num_coefficients() {
-            *model.coefficient(ci) = *model.coefficient(ci) -
-                                    self.learning_rate *
-                                    gradient(cost, prediction, truth, model.gradient(ci, features));
+            *model.coefficient(ci) =
+                *model.coefficient(ci) -
+                self.learning_rate *
+                gradient(cost, prediction, truth, model.gradient(ci, features));
         }
     }
 }
@@ -76,7 +77,7 @@ pub struct GradientDescentAl {
 }
 
 impl<M> Teacher<M> for GradientDescentAl
-    where M: Model
+    where M: Model<Target = f64>
 {
     type Training = usize;
 
@@ -85,11 +86,11 @@ impl<M> Teacher<M> for GradientDescentAl
     }
 
     fn teach_event<Y, C>(&self,
-                            num_events: &mut usize,
-                            model: &mut M,
-                            cost: &C,
-                            features: &M::Features,
-                            truth: Y)
+                         num_events: &mut usize,
+                         model: &mut M,
+                         cost: &C,
+                         features: &M::Features,
+                         truth: Y)
         where C: Cost<Y>,
               Y: Copy
     {
@@ -97,9 +98,9 @@ impl<M> Teacher<M> for GradientDescentAl
         let learning_rate = annealed_learning_rate(*num_events, self.l0, self.t);
 
         for ci in 0..model.num_coefficients() {
-            *model.coefficient(ci) = *model.coefficient(ci) -
-                                    learning_rate *
-                                    gradient(cost, prediction, truth, model.gradient(ci, features));
+            *model.coefficient(ci) =
+                *model.coefficient(ci) -
+                learning_rate * gradient(cost, prediction, truth, model.gradient(ci, features));
         }
         *num_events += 1;
     }
@@ -122,7 +123,7 @@ pub struct Momentum {
 }
 
 impl<M> Teacher<M> for Momentum
-    where M: Model
+    where M: Model<Target = f64>
 {
     type Training = (usize, Vec<f64>);
 
@@ -135,11 +136,11 @@ impl<M> Teacher<M> for Momentum
     }
 
     fn teach_event<Y, C>(&self,
-                            training: &mut (usize, Vec<f64>),
-                            model: &mut M,
-                            cost: &C,
-                            features: &M::Features,
-                            truth: Y)
+                         training: &mut (usize, Vec<f64>),
+                         model: &mut M,
+                         cost: &C,
+                         features: &M::Features,
+                         truth: Y)
         where C: Cost<Y>,
               Y: Copy
     {
@@ -182,7 +183,7 @@ pub struct Nesterov {
 }
 
 impl<M> Teacher<M> for Nesterov
-    where M: Model
+    where M: Model<Target = f64>
 {
     type Training = (usize, Vec<f64>);
 
@@ -195,11 +196,11 @@ impl<M> Teacher<M> for Nesterov
     }
 
     fn teach_event<Y, C>(&self,
-                            training: &mut (usize, Vec<f64>),
-                            model: &mut M,
-                            cost: &C,
-                            features: &M::Features,
-                            truth: Y)
+                         training: &mut (usize, Vec<f64>),
+                         model: &mut M,
+                         cost: &C,
+                         features: &M::Features,
+                         truth: Y)
         where C: Cost<Y>,
               Y: Copy
     {
@@ -228,15 +229,15 @@ impl<M> Teacher<M> for Nesterov
 /// each coefficient. In effect the learning rate is smaller for frequent and larger for infrequent
 /// features.
 /// See [this paper](http://jmlr.org/papers/v12/duchi11a.html) for more information.
-pub struct Adagard{
+pub struct Adagard {
     /// The larger this parameter is, the more the coefficients will change with each iteration
-    pub learning_rate : f64,
+    pub learning_rate: f64,
     /// Small smoothing term, to avoid division by zero in first iteration
-    pub epsilon : f64
+    pub epsilon: f64,
 }
 
 impl<M> Teacher<M> for Adagard
-    where M: Model
+    where M: Model<Target = f64>
 {
     type Training = Vec<f64>;
 
@@ -248,13 +249,13 @@ impl<M> Teacher<M> for Adagard
     }
 
     fn teach_event<Y, C>(&self,
-                        squared_gradients: &mut Vec<f64>,
-                        model: &mut M,
-                        cost: &C,
-                        features: &M::Features,
-                        truth: Y)
-    where C: Cost<Y>,
-            Y: Copy
+                         squared_gradients: &mut Vec<f64>,
+                         model: &mut M,
+                         cost: &C,
+                         features: &M::Features,
+                         truth: Y)
+        where C: Cost<Y>,
+              Y: Copy
     {
 
         let prediction = model.predict(features);

--- a/src/teacher.rs
+++ b/src/teacher.rs
@@ -36,7 +36,8 @@ pub struct GradientDescent {
 }
 
 impl<M> Teacher<M> for GradientDescent
-    where M: Model<Target = f64>
+    where M: Model,
+          M::Target: Vector
 {
     type Training = ();
 
@@ -50,7 +51,7 @@ impl<M> Teacher<M> for GradientDescent
                          cost: &C,
                          features: &M::Features,
                          truth: Y)
-        where C: Cost<Y>,
+        where C: Cost<Y, M::Target>,
               Y: Copy
     {
         let prediction = model.predict(features);
@@ -79,7 +80,8 @@ pub struct GradientDescentAl {
 }
 
 impl<M> Teacher<M> for GradientDescentAl
-    where M: Model<Target = f64>
+    where M: Model,
+          M::Target: Vector
 {
     type Training = usize;
 
@@ -93,7 +95,7 @@ impl<M> Teacher<M> for GradientDescentAl
                          cost: &C,
                          features: &M::Features,
                          truth: Y)
-        where C: Cost<Y>,
+        where C: Cost<Y, M::Target>,
               Y: Copy
     {
         let prediction = model.predict(features);
@@ -125,7 +127,8 @@ pub struct Momentum {
 }
 
 impl<M> Teacher<M> for Momentum
-    where M: Model<Target = f64>
+    where M: Model,
+          M::Target: Vector
 {
     type Training = (usize, Vec<f64>);
 
@@ -143,12 +146,10 @@ impl<M> Teacher<M> for Momentum
                          cost: &C,
                          features: &M::Features,
                          truth: Y)
-        where C: Cost<Y>,
+        where C: Cost<Y, M::Target>,
               Y: Copy
     {
-        // let (ref mut num_events, ref mut velocity) = *training; ok?
-        let mut num_events = &mut training.0;
-        let mut velocity = &mut training.1;
+        let (ref mut num_events, ref mut velocity) = *training;
         let prediction = model.predict(features);
         let learning_rate = annealed_learning_rate(*num_events, self.l0, self.t);
 
@@ -207,8 +208,7 @@ impl<M> Teacher<M> for Nesterov
         where C: Cost<Y, M::Target>,
               Y: Copy
     {
-        let mut num_events = &mut training.0;
-        let mut velocity = &mut training.1;
+        let (ref mut num_events, ref mut velocity) = *training;
         let prediction = model.predict(features);
         let learning_rate = annealed_learning_rate(*num_events, self.l0, self.t);
 
@@ -239,7 +239,8 @@ pub struct Adagard {
 }
 
 impl<M> Teacher<M> for Adagard
-    where M: Model<Target = f64>
+    where M: Model,
+          M::Target: Vector
 {
     type Training = Vec<f64>;
 
@@ -256,7 +257,7 @@ impl<M> Teacher<M> for Adagard
                          cost: &C,
                          features: &M::Features,
                          truth: Y)
-        where C: Cost<Y>,
+        where C: Cost<Y, M::Target>,
               Y: Copy
     {
 


### PR DESCRIPTION
The model trait now supports a target types different from `f64`. This extensions of the trait has been used to support a OneVsRest model in the library. The iris sample has therefore been stripped of its custom model implementation and uses the one from the library instead.